### PR TITLE
test 페이지 모델 수정 및 버그 수정

### DIFF
--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -84,7 +84,7 @@ export default function TurtleNeckUploadPage() {
       landmarkerRef.current = await PoseLandmarker.createFromOptions(vision, {
         baseOptions: {
           modelAssetPath:
-            "https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_full/float16/1/pose_landmarker_full.task",
+            "https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task",
         },
         runningMode: "VIDEO",
         numPoses: 1,
@@ -221,14 +221,16 @@ export default function TurtleNeckUploadPage() {
         lm8 = p[8],
         lm11 = p[11],
         lm12 = p[12];
+
+        
       const turtle = isTurtleNeck(
         { x: lm7.x, y: lm7.y, z: lm7.z },
         { x: lm8.x, y: lm8.y, z: lm8.z },
         { x: lm11.x, y: lm11.y, z: lm11.z },
         { x: lm12.x, y: lm12.y, z: lm12.z }
-      );
+      ).isTurtle;
 
-      setStatus(turtle ? "turtle" : "good");
+      setStatus(turtle? "turtle" : "good");
       handleTurtleTimeline(turtle, v.currentTime);
 
       const row = [


### PR DESCRIPTION
테스트 페이지에서 거북목 함수 정확도 평가하는데 쓰이는 모델이 실사용 모델과 달라서 고쳐놓았습니다!
(full -> lite)

그리고 page.tsx 내부에 쓰이는 변수 turtle과 isturtle 함수의 리턴값의 타입이 맞지 않아
함수가 정상 자세로 판단했는데도 거북목으로 출력되는 버그 확인했고
이 역시 고쳤습니다!