### PR TITLE
fix: 측정 페이지 통계 버그 수정

### DIFF
--- a/src/app/estimate/page.tsx
+++ b/src/app/estimate/page.tsx
@@ -64,7 +64,7 @@ export default function Estimate() {
 
   if (!userId || !sessionId) return <div>loading</div>;
 
-  usePostureStorageManager(userId, angle, isTurtle, sessionId);
+  usePostureStorageManager(userId,angle, isTurtle, sessionId, measuringRef.current);
 
   // 🔹 "거북목 측정을 시작합니다" 토스트 자동 숨김
   useEffect(() => {

--- a/src/hooks/usePostureStorageManager.ts
+++ b/src/hooks/usePostureStorageManager.ts
@@ -12,12 +12,20 @@ import { PostureMeasurement } from "@/lib/postureLocal";
  * @param isTurtle - 현재 거북목 여부
  * @param sessionId - 세션 식별자
  */
-export function usePostureStorageManager(userId: string, currentAngle: number, isTurtle: boolean, sessionId: string) {
+export function usePostureStorageManager(
+  userId: string,
+  currentAngle: number,
+  isTurtle: boolean,
+  sessionId: string,
+  measuring: boolean
+) {
   useEffect(() => {
     if (!userId) return;
     const SAMPLE_GAP_S = 10;
 
     const interval = setInterval(async () => {
+      if (!measuring) return;
+      
       const now = Date.now();
       const sample: PostureMeasurement = {
         userId,


### PR DESCRIPTION
원인: 측정 중단 시에도 IndexedDB에 데이터가 계속 저장되고 있었음
측정 중단 시(즉 stopEstimating == true)일 때는 각도가 0인데, 이게 10초 동안의 훅에 계속 저장되면서
평균 각도가 크게 줄어듦

해결 방법: usePostureStorageManager 함수에 현재 측정 중인지 판단하는 boolean값(measuringRef.current)을 직접 넘겨 줘서
측정 중단 시에는 예외처리

resolve #83 