### PR TITLE
fix: 백그라운드에서도 거북목 측정 가능하게 수정

### DIFF
--- a/src/components/organisms/layout/Header.tsx
+++ b/src/components/organisms/layout/Header.tsx
@@ -81,7 +81,7 @@ export default function Header({ user: initialUser, className }: HeaderProps) {
         ) : (
           // 일반 페이지: 3열 그리드 레이아웃
           <div className="grid grid-cols-[1fr_auto_1fr] items-center">
-            {/* Left: Logo */}
+        {/* Left: Logo */}
             <div className="flex items-center justify-start">
               <Link href="/" className="flex items-center gap-2 text-xl font-bold" style={{ color: "#2D5F2E", textDecoration: "none" }}>
                 <div
@@ -95,7 +95,7 @@ export default function Header({ user: initialUser, className }: HeaderProps) {
                   />
                 </div>
                 <span>거북목 거북거북!</span>
-              </Link>
+        </Link>
             </div>
 
             {/* Center: 네비게이션 */}
@@ -118,19 +118,19 @@ export default function Header({ user: initialUser, className }: HeaderProps) {
                   </Link>
                 );
               })}
-            </nav>
+        </nav>
 
             {/* Right: 프로필 */}
             <div className="flex items-center justify-end">
-              {isLoading ? (
-                <span className="text-sm text-black/40">...</span>
-              ) : user ? (
+          {isLoading ? (
+            <span className="text-sm text-black/40">...</span>
+          ) : user ? (
                 <div className="relative" ref={userMenuAnchorRef}>
                   <button
                     onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}
                     className="bg-[#E8F5E9] text-[#2D5F2E] border-2 border-[#7BC67E] px-5 py-2 rounded-[25px] font-semibold cursor-pointer transition-all duration-300 text-base hover:bg-[#7BC67E] hover:text-white hover:-translate-y-0.5 hover:shadow-[0_4px_12px_rgba(123,198,126,0.3)]"
                   >
-                    {user.name ?? "사용자"}
+                {user.name ?? "사용자"}
                   </button>
                   <UserMenuDropdown
                     userName={user.name ?? "사용자"}
@@ -140,11 +140,11 @@ export default function Header({ user: initialUser, className }: HeaderProps) {
                     onClose={() => setIsUserMenuOpen(false)}
                     anchorRef={userMenuAnchorRef}
                   />
-                </div>
-              ) : (
-                <Button onClick={() => signIn()}>로그인</Button>
-              )}
             </div>
+          ) : (
+            <Button onClick={() => signIn()}>로그인</Button>
+          )}
+        </div>
           </div>
         )}
       </div>

--- a/src/components/templates/HomeTemplate.tsx
+++ b/src/components/templates/HomeTemplate.tsx
@@ -49,9 +49,9 @@ export default function HomeTemplate({
   return (
     <main className={["bg-[#F8FBF8] min-h-screen", className].filter(Boolean).join(" ")}>
       <div className="max-w-[1400px] mx-auto px-8 py-8">
-        <WelcomeHero userName={user?.name ?? "사용자"} />
+      <WelcomeHero userName={user?.name ?? "사용자"} />
 
-        {/* 본문 2열 레이아웃: 좌(KPI), 우(도전기) */}
+      {/* 본문 2열 레이아웃: 좌(KPI), 우(도전기) */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mt-8">
           {/* LEFT: 오늘의 거북목 섹션 */}
           <div className="flex flex-col gap-6">


### PR DESCRIPTION
### 문제점
### 1. 백그라운드에서 측정이 멈추는 문제
**원인**: requestAnimationFrame이 백그라운드에서 throttling됨
Chrome: 최대 1fps로 제한
Firefox: 완전히 중지될 수 있음
**증상**:
백그라운드로 전환 시 프레임 처리 거의 중단
MediaPipe 분석이 거의 실행되지 않음
거북목 판별이 업데이트되지 않음
경고음이 이전 상태에 고정됨
### 2. 사용자 보고 버그
거북목 상태에서 백그라운드로 전환 후 정상 자세로 돌아와도 경고음이 계속 재생
정상 상태에서 백그라운드로 전환 후 거북목 자세를 해도 경고음이 울리지 않음

### 변경 사항
1. requestAnimationFrame → setInterval 변경
rafRef를 intervalRef로 변경하고 타입을 NodeJS.Timeout | null로 변경
requestAnimationFrame을 setInterval로 교체
2. 페이지 visibility에 따른 프레임 레이트 조절
포그라운드: 30fps (33ms 간격)
백그라운드: 10fps (100ms 간격)
3. visibility 변경 감지
visibilitychange 이벤트 리스너 추가
탭 전환 시 프레임 레이트 자동 조절
4. Cleanup 로직 개선
clearInterval로 interval 정리
이벤트 리스너 제거

### 결과
백그라운드에서도 거북목 측정이 가능
웹캠 스트림은 계속 실행
MediaPipe 분석이 백그라운드에서도 실행
거북목 판별 로직이 정상 업데이트
경고음이 상태에 맞게 작동
백그라운드에서는 10fps로 동작해 배터리 소모를 줄이면서도 측정이 계속됩니다.