### PR TITLE
민감도 수치 조정

### DIFF
--- a/src/utils/isTurtleNeck.ts
+++ b/src/utils/isTurtleNeck.ts
@@ -85,11 +85,11 @@ export default function isTurtleNeck({ earLeft, earRight, shoulderLeft, shoulder
       threshold = 45; // 더 관대하게 (45도 이하만 거북목)
       break;
     case "high":
-      threshold = 53; // 더 엄격하게 (53도 이하만 거북목)
+      threshold = 50; // 더 엄격하게 (50도 이하만 거북목)
       break;
     case "normal":
     default:
-      threshold = 51; // 기본값 (51도 이하만 거북목)
+      threshold = 48; // 기본값 (48도 이하만 거북목)
       break;
   }
 

--- a/src/utils/sensitivity.ts
+++ b/src/utils/sensitivity.ts
@@ -50,9 +50,9 @@ export function getSensitivityLabel(sensitivity: Sensitivity): string {
 export function getSensitivityThresholds(sensitivity: Sensitivity): { enter: number; exit: number } {
   switch (sensitivity) {
     case "low":
-      return { enter: 45, exit: 48 };
+      return { enter: 45, exit: 51 };
     case "high":
-      return { enter: 50, exit: 53 };
+      return { enter: 50, exit: 51 };
     case "normal":
     default:
       return { enter: 48, exit: 51 };

--- a/src/utils/turtleStabilizer.ts
+++ b/src/utils/turtleStabilizer.ts
@@ -15,11 +15,11 @@ export default function turtleStabilizer(angleDeg: number, sensitivity: Sensitiv
   switch (sensitivity) {
     case "low":
       ENTER_THRESHOLD = 45;  // 낮음 (45도 이하에서 거북목 진입)
-      EXIT_THRESHOLD = 48;   // 낮음 (48도 이상에서 정상 복귀)
+      EXIT_THRESHOLD = 51;   // 낮음 (51도 이상에서 정상 복귀)
       break;
     case "high":
       ENTER_THRESHOLD = 50;  // 높음 (50도 이하에서 거북목 진입)
-      EXIT_THRESHOLD = 53;   // 높음 (53도 이상에서 정상 복귀)
+      EXIT_THRESHOLD = 51;   // 높음 (51도 이상에서 정상 복귀)
       break;
     case "normal":
     default:


### PR DESCRIPTION
기존의 민감도 수치는 

낮음 (45도 이하에서 거북목 진입, 48도 이상에서 정상 복귀)
보통 (48도 이하에서 거북목 진입, 51도 이상에서 정상 복귀)
높음(50도 이하에서 거북목 진입, 53도 이상에서 정상 복귀)

이었습니다.

민감도는 거북목 상태에 얼마나 민감한지에 관한 수치이므로,
예를 들어 민감도가 높을 때 정상으로 돌아가기 위한 각도가 높아져 오히려 복귀가 어려워진다면
오히려 민감도가 낮아진 거라 볼 수 있습니다.

따라서 정상 복귀에 필요한 각도를 모두 51도로 조정하였습니다.